### PR TITLE
fix domain path

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -3,7 +3,7 @@ export default class CareApi {
         var content;
 
         (async() => {
-            const response = await fetch('http://user.epicare.fr/' + npath, {
+            const response = await fetch('http://epicare.fr:8080/' + npath, {
                 method: method,
                 headers: {
                     'Accept': 'application/json',


### PR DESCRIPTION
The API has some problem with redirections. The requests only work with this path : http://epicare.fr:8080/